### PR TITLE
do not use mupdf

### DIFF
--- a/willuslib/willus.h
+++ b/willuslib/willus.h
@@ -230,11 +230,9 @@ typedef double  real;
 #ifndef HAVE_JPEG_LIB
 #define HAVE_JPEG_LIB
 #endif
-*/
 #ifndef HAVE_MUPDF_LIB
 #define HAVE_MUPDF_LIB
 #endif
-/*
 #ifndef HAVE_GHOSTSCRIPT
 #define HAVE_GHOSTSCRIPT
 #endif


### PR DESCRIPTION
We didn't use it before anyway, since we used functionality working
on bitmaps, rather than PDF files. So do not use (and link - again!)
MuPDF here.

Fixes (in combination with a fix for koreader-base Makefile) https://github.com/koreader/koreader-base/issues/288
