### PR TITLE
Add ANDROID definition to tesseract when we are building with android toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ $(TESSERACT_LIB): $(LEPTONICA_LIB)
 		CXX='$(strip $(CCACHE) $(CXX))' \
 		CXXFLAGS='$(CXXFLAGS) -I$(MOD_INC)' \
 		$(if $(WIN32),CPPFLAGS='-D_tagBLOB_DEFINED',) \
+		$(if $(ANDROID),CPPFLAGS='-DANDROID=1',) \
 		LIBLEPT_HEADERSDIR=$(LEPTONICA_DIR)/src \
 		LDFLAGS='$(STDCPPLIB) $(LEPT_LDFLAGS) -Wl,-rpath,\$$$$ORIGIN $(ZLIB_LDFLAGS) $(PNG_LDFLAGS)' \
 		--with-extra-libraries=$(LEPTONICA_DIR)/src/.libs \


### PR DESCRIPTION
This is part of Android NDK upgrade change. Currently with latest Android NDK 11c, we have bunch of build errors, the details are discussed in issue #2043.

AFAICT, latest Android NDK 11c won't add definition ANDROID by default, this change would break tesseract build.

I would prefer to fix this issue in root, but k2pdfopt is not hosted on any known opensource platform.