### PR TITLE
implement pixmap_to_bmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(LEPTONICA_LIB):
 		CC='$(strip $(CCACHE) $(CC))' CFLAGS='$(LEPT_CFLAGS)' \
 		LDFLAGS='$(LEPT_LDFLAGS) -Wl,-rpath,"libs" $(ZLIB_LDFLAGS) $(PNG_LDFLAGS)' \
 		--disable-static --enable-shared \
-		--with-zlib --with-libpng --without-jpeg --without-giflib --without-libtiff
+		--with-zlib --with-libpng --without-jpeg --without-giflib --without-libtiff --without-libopenjpeg
 	# fix cannot find library -lc on mingw-w64
 	cd $(LEPTONICA_DIR) && sed -ie "s|archive_cmds_need_lc='yes'|archive_cmds_need_lc='no'|" config.status
 	cd $(LEPTONICA_DIR) && chmod +x config/install-sh # fix Permission denied on OSX

--- a/koptreflow.c
+++ b/koptreflow.c
@@ -31,6 +31,38 @@
 #include "koptreflow.h"
 #include "leptonica.h"
 
+void pixmap_to_bmp(WILLUSBITMAP *bmp, unsigned char *pix_data, int ncomp) {
+    int i,j;
+    unsigned char *b, *p;
+
+    if (ncomp == 2) {
+        bmp->bpp = 8;
+        bmp_alloc(bmp);
+        // set palette
+        for (i = 0; i < 256; i++)
+            bmp->red[i] = bmp->blue[i] = bmp->green[i] = i;
+        for (i = 0; i < bmp->height; i++) {
+            b = bmp_rowptr_from_top(bmp, i);
+            p = pix_data + 2*i*bmp->width;
+            for (j = 0; j < bmp->width; j++) {
+                b[j] = p[2*j];
+            }
+        }
+    } else if (ncomp == 4) {
+        bmp->bpp = 24;
+        bmp_alloc(bmp);
+        for (i = 0; i < bmp->height; i++) {
+            b = bmp_rowptr_from_top(bmp, i);
+            p = pix_data + 4*i*bmp->width;
+            for (j = 0; j < bmp->width; j++) {
+                b[j] = p[4*j];
+                b[j+1] = p[4*j+1];
+                b[j+2] = p[4*j+2];
+            }
+        }
+    }
+}
+
 void k2pdfopt_reflow_bmp(KOPTContext *kctx) {
     K2PDFOPT_SETTINGS _k2settings, *k2settings;
     MASTERINFO _masterinfo, *masterinfo;

--- a/koptreflow.h
+++ b/koptreflow.h
@@ -25,6 +25,7 @@
 #include "context.h"
 
 void k2pdfopt_reflow_bmp(KOPTContext *kctx);
+void pixmap_to_bmp(WILLUSBITMAP *bmp, unsigned char *pix_data, int ncomp);
 
 #endif
 


### PR DESCRIPTION
This implementation will replace the `ffi` version in `ffi/mupdf.lua`. Because we are going to disable `jit` on some platforms.