### PR TITLE
ignore quality when using dewatermark

### DIFF
--- a/koptcrop.c
+++ b/koptcrop.c
@@ -63,8 +63,8 @@ void k2pdfopt_crop_bmp(KOPTContext *kctx) {
 	bmpregion_init(region);
 	masterinfo_new_source_page_init(masterinfo, k2settings, src, srcgrey, NULL,
 			region, k2settings->src_rot, NULL, NULL, 1, -1, NULL);
-	printf("source page (%d,%d) - (%d,%d)\n",region->c1,region->r1,region->c2,region->r2);
-	printf("source page bgcolor %d\n", region->bgcolor);
+	//printf("source page (%d,%d) - (%d,%d)\n",region->c1,region->r1,region->c2,region->r2);
+	//printf("source page bgcolor %d\n", region->bgcolor);
 	bmpregion_trim_margins(region,k2settings,0xf);
 	margin = kctx->margin*k2settings->dst_dpi;
 	/*

--- a/koptimize.c
+++ b/koptimize.c
@@ -53,6 +53,7 @@ void k2pdfopt_optimize_bmp(KOPTContext *kctx) {
     k2settings->text_wrap=0;
     k2settings->max_columns=1;
     k2settings->vertical_break_threshold=-2;
+    k2settings->src_dpi=kctx->dev_dpi;
     k2settings->dst_userwidth=1.0;
     k2settings->dst_userwidth_units=UNITS_SOURCE;
     k2settings->dst_userheight=1.0;


### PR DESCRIPTION
part of the settings passed to libk2pdfopt is `quality` used by reflow and can only be set when reflow is on.
dewatermark also uses libk2pdfopt and the `quality` setting was causing the document to be scaled wrong.
reflow and dewatermark are mutually exclusive

dewatermark in koreader is optimize in libk2pdfopt

closes koreader/koreader#6340
closes koreader/koreader#5878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/38)
<!-- Reviewable:end -->
