### PR TITLE
fix build with GCC 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ K2PDFOPT_LIB= libk2pdfopt$(if $(WIN32),-$(MAJVER).dll,$(if $(DARWIN),.$(MAJVER).
 # Target file rules.
 ##############################################################################
 $(LEPTONICA_LIB):
-	cp -f $(LEPTONICA_MOD)/dewarp2.c $(LEPTONICA_DIR)/src/dewarp2.c
+	cp -f $(addprefix $(LEPTONICA_MOD)/,allheaders.h dewarp2.c) $(LEPTONICA_DIR)/src/
 	# leptonica 1.73 and up requires to run autobuild first
 	cd $(LEPTONICA_DIR) && ! test -f ./configure && sh ./autobuild || true
 	# No stupid build rpaths


### PR DESCRIPTION
Arch Linux just updated to `gcc 14.1.1`:
```
dewarp2.c: In function ‘dewarpBuildPageModel’:
dewarp2.c:144:8: error: implicit declaration of function ‘dewarpBuildPageModel_ex’; did you mean ‘dewarpBuildPageModel’? [-Wimplicit-function-declaration]
  144 | return(dewarpBuildPageModel_ex(dew,debugfile,2));
      |        ^~~~~~~~~~~~~~~~~~~~~~~
      |        dewarpBuildPageModel
dewarp2.c: In function ‘dewarpBuildPageModel_ex’:
dewarp2.c:230:9: error: implicit declaration of function ‘dewarpFindVertDisparity_ex’; did you mean ‘dewarpFindVertDisparity’? [-Wimplicit-function-declaration]
  230 |     if (dewarpFindVertDisparity_ex(dew, ptaa2, 0, fit_order) != 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |         dewarpFindVertDisparity
dewarp2.c: In function ‘dewarpBuildLineModel’:
dewarp2.c:1411:8: error: implicit declaration of function ‘dewarpBuildLineModel_ex’; did you mean ‘dewarpBuildPageModel_ex’? [-Wimplicit-function-declaration]
 1411 | return(dewarpBuildLineModel_ex(dew,opensize,debugfile,2));
      |        ^~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/46)
<!-- Reviewable:end -->
