### PR TITLE
trim the fat

### DIFF
--- a/k2pdfoptlib/bmpregion.c
+++ b/k2pdfoptlib/bmpregion.c
@@ -70,7 +70,7 @@ int bmpregion_col_black_count(BMPREGION *region,int c0)
     }
 
 
-// #if (defined(WILLUSDEBUGX) || defined(WILLUSDEBUG))
+#if (defined(WILLUSDEBUGX) || defined(WILLUSDEBUG))
 void bmpregion_write(BMPREGION *region,char *filename)
 
     {
@@ -96,7 +96,7 @@ void bmpregion_write(BMPREGION *region,char *filename)
     bmp_write(bmp,filename,stdout,97);
     bmp_free(bmp);
     }
-// #endif
+#endif
 
 void bmpregion_row_histogram(BMPREGION *region)
 

--- a/k2pdfoptlib/devprofile.c
+++ b/k2pdfoptlib/devprofile.c
@@ -143,6 +143,7 @@ DEVPROFILE *devprofile_get(char *name)
     }
 
 
+#if 0
 char *devprofile_select(void)
 
     {
@@ -164,3 +165,4 @@ char *devprofile_select(void)
         }
     return(NULL);
     }
+#endif

--- a/k2pdfoptlib/k2file.c
+++ b/k2pdfoptlib/k2file.c
@@ -64,6 +64,7 @@ static int k2file_setup_output_file_names(K2PDFOPT_SETTINGS *k2settings,char *fi
                                           MASTERINFO *masterinfo,
                                           char *dstfile,char *markedfile,PDFFILE *mpdf);
 
+#if 0
 
 /*
 ** If arg is a file wildcard specification, then figure out all matches and pass
@@ -1254,6 +1255,8 @@ masterinfo->preview_bitmap->width,masterinfo->preview_bitmap->height,masterinfo-
     return(status);
     }
 
+#endif
+
 
 static char *pagename(int pageno)
 
@@ -1829,6 +1832,7 @@ int k2file_get_num_pages(char *filename)
     }
 
 
+#if 0
 void k2file_get_overlay_bitmap(WILLUSBITMAP *bmp,double *dpi,char *filename,char *pagelist)
 
     {
@@ -1889,6 +1893,7 @@ void k2file_get_overlay_bitmap(WILLUSBITMAP *bmp,double *dpi,char *filename,char
         }
     bmp_free(tmp);
     }
+#endif
 
 
 void k2file_look_for_pagebreakmarks(K2PAGEBREAKMARKS *k2pagebreakmarks,
@@ -2065,6 +2070,8 @@ static void gs_postprocess(char *filename)
     k2printf(TTEXT_BOLD "    ... %d bytes" TTEXT_NORMAL " written to " TTEXT_MAGENTA "%s" TTEXT_NORMAL " (%.1f MB).\n",(int)size,filename,size/1024./1024.);
     }
 #endif
+
+#if 0
 
 static void gs_conv_cleanup(int psconv,char *filename,char *original_file)
 
@@ -2355,3 +2362,5 @@ static int k2file_setup_output_file_names(K2PDFOPT_SETTINGS *k2settings,char *fi
         }
     return(1);
     }
+
+#endif

--- a/k2pdfoptlib/k2mark.c
+++ b/k2pdfoptlib/k2mark.c
@@ -22,6 +22,7 @@
 
 int k2mark_page_count=0;
 
+#if 0
 /*
 ** src guaranteed to be 24-bit color
 */
@@ -65,6 +66,7 @@ bmp_write(src,filename,stdout,100);
         pdffile_add_bitmap(mpdf,bmp,newdpi,-1,1);
     bmp_free(bmp);
     }
+#endif
 
 
 /*

--- a/k2pdfoptlib/k2master.c
+++ b/k2pdfoptlib/k2master.c
@@ -64,9 +64,11 @@ void masterinfo_init(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
     int i;
 
     /* Init outline / bookmarks */
+#if 0
     masterinfo->outline=NULL;
     masterinfo->output_page_count=0;
     masterinfo->outline_srcpage_completed=-1;
+#endif
     masterinfo->preview_bitmap=NULL;
     masterinfo->preview_captured=0;
     masterinfo->published_pages=0;
@@ -80,11 +82,13 @@ void masterinfo_init(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
     bmp_init(&masterinfo->bmp);
     /* v2.53 -- Added queueing of OCR and pages to help parallelize OCR */
     ocrwords_init(&masterinfo->mi_ocrwords);
+#if 0
     masterinfo->queued_page_info.na=32;
     masterinfo->queued_page_info.n=0;
     willus_mem_alloc_warn((void **)&masterinfo->queued_page_info.page,
                             sizeof(QUEUED_PAGE)*masterinfo->queued_page_info.na,
                             funcname,10);
+#endif
     /* v2.53 end */
     masterinfo->bmp.height=masterinfo->bmp.width=0;
     masterinfo->bmp.bpp=k2settings->dst_color ? 24 : 8;
@@ -123,6 +127,7 @@ void masterinfo_init(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
     sprintf(masterinfo->pageinfo.producer,"K2pdfopt %s",k2pdfopt_version);
     }
 
+#if 0
 
 static void masterinfo_pagequeue_queue_page(MASTERINFO *masterinfo,int rowcount,int srcpageno)
 
@@ -158,6 +163,7 @@ static int masterinfo_pagequeue_row_start(MASTERINFO *masterinfo)
     return(sum);
     }
 
+#endif
 
 void masterinfo_free(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
 
@@ -173,12 +179,16 @@ void masterinfo_free(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
 #ifdef K2PDFOPT_KINDLEPDFVIEWER
     wrectmaps_free(&masterinfo->rectmaps);
 #endif
+#if 0
     wpdfoutline_free(masterinfo->outline);
+#endif
     ocrwords_free(&masterinfo->mi_ocrwords);
+#if 0
     /* Clear page queue */
     willus_mem_free((double **)&masterinfo->queued_page_info.page,funcname);
     masterinfo->queued_page_info.n=0;
     masterinfo->queued_page_info.na=0;
+#endif
     }
 
 
@@ -303,6 +313,7 @@ printf("Done autocrop.\n");
         dwbmp=&_dwbmp;
         bmp_init(dwbmp);
         bmp_copy(dwbmp,srcgrey);
+#ifdef K2PDFOPT_DEBUG
         if (k2settings->debug)
             {
             bmp_write(dwbmp,"dewarp_pre_prep.png",NULL,100);
@@ -310,9 +321,11 @@ printf("Done autocrop.\n");
             wfile_written_info("dewarp_pre_prep.png",stdout);
             aprintf(TTEXT_NORMAL);
             }
+#endif
         k2bmp_prep_for_dewarp(dwbmp,srcgrey,k2settings->src_dpi/45,white);
         if (k2settings->autocrop)
             k2bmp_apply_autocrop(dwbmp,masterinfo->autocrop_margins);
+#ifdef K2PDFOPT_DEBUG
         if (k2settings->debug)
             {
             bmp_write(dwbmp,"dewarp_image.png",NULL,100);
@@ -320,14 +333,17 @@ printf("Done autocrop.\n");
             wfile_written_info("dewarp_image.png",stdout);
             aprintf(TTEXT_NORMAL);
             }
+#endif
         wlept_bmp_dewarp(dwbmp,src,srcgrey,white,k2settings->dewarp,
                          k2settings->debug?"k2opt_dewarp_model.pdf":NULL);
+#ifdef K2PDFOPT_DEBUG
         if (k2settings->debug)
             {
             aprintf(TTEXT_BOLD);
             wfile_written_info("k2opt_dewarp_model.pdf",stdout);
             aprintf(TTEXT_NORMAL);
             }
+#endif
         bmp_free(dwbmp);
         /* Re-do autocrop after de-warp */
         if (k2settings->autocrop)
@@ -372,6 +388,7 @@ printf("22\n");
     region->bbox.c2 = region->c2;
     region->bbox.r1 = region->r1;
     region->bbox.r2 = region->r2;
+#ifdef K2PDFOPT_DEBUG
     if (k2settings->show_marked_source)
         {
         if (k2settings->dst_color && marked!=NULL)
@@ -382,6 +399,7 @@ printf("22\n");
         else
             region->marked=region->bmp;
         }
+#endif
     masterinfo->bgcolor=white;
     /* dst_fit_to_page == -2 if gridding */
     masterinfo->fit_to_page = k2settings->dst_fit_to_page;
@@ -1180,6 +1198,7 @@ printf("lastrow->gap now = %d(r2) - %d(rowbase) = %d\n",region->r2,textrow[n-1].
     }
 
 
+#if 0
 static void masterinfo_pagequeue_pop_queue(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings)
 
     {
@@ -1193,6 +1212,7 @@ static void masterinfo_pagequeue_pop_queue(MASTERINFO *masterinfo,K2PDFOPT_SETTI
     qpi->n--;
     masterinfo_remove_top_rows(masterinfo,k2settings,rowcount);
     }
+#endif
 
 
 static void masterinfo_remove_top_rows(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS *k2settings,int rows)
@@ -1272,6 +1292,7 @@ static int masterinfo_pageheight_pixels(MASTERINFO *masterinfo,K2PDFOPT_SETTINGS
     return(pheight);
     }
 
+#if 0
 
 /*
 **
@@ -1729,6 +1750,7 @@ printf("@masterinfo_should_flush, breakpages=%d\n",k2settings->dst_break_pages);
     return(wpdfoutline_includes_srcpage(masterinfo->outline,masterinfo->nextpage,1)>0 ? 1 : 0);
     }
 
+#endif
 
 /*
 ** Correctly complete crop boxes that are associated with this output page

--- a/k2pdfoptlib/k2ocr.c
+++ b/k2pdfoptlib/k2ocr.c
@@ -187,14 +187,18 @@ void k2ocr_init(K2PDFOPT_SETTINGS *k2settings,char *initstr)
                 }
             else
                 {
+#if 0
                 sprintf(ocrinitmessage,"Could not initialize any Tesseract threads.\n"
                      "Possibly could not find Tesseract data (env var TESSDATA_PREFIX = %s).\n"
                      "Using GOCR v0.50.\n\n",
                      getenv("TESSDATA_PREFIX")==NULL?"(not assigned)":getenv("TESSDATA_PREFIX"));
+#endif
                 k2ocr_tess_status=-1;
                 maxthreads=1;
+#if 0
                 k2printf(TTEXT_WARN "%s" TTEXT_NORMAL,ocrinitmessage);
                 k2ocr_showlog();
+#endif
                 }
             strcat(initstr,ocrinitmessage);
             willus_mem_free((double **)&otii,funcname);
@@ -235,6 +239,9 @@ void k2ocr_init(K2PDFOPT_SETTINGS *k2settings,char *initstr)
 
 
 #ifdef HAVE_TESSERACT_LIB
+
+#if 0
+
 void ocrtess_debug_info(char **buf0,int use_ansi)
 
     {
@@ -294,6 +301,7 @@ static void k2ocr_status_line(char *buf,char *color,char *label,char *string)
     strcat(buf,"\n");
     }
 
+#endif
 
 void k2ocr_tesslang_selected(char *lang,int maxlen,K2PDFOPT_SETTINGS *k2settings)
 
@@ -417,6 +425,7 @@ static void *otinit(void *data)
     }
 #endif
 
+#if 0
 
 /*
 ** Dump Tesseract library debugging log using k2printf()
@@ -499,6 +508,7 @@ void k2ocr_end(K2PDFOPT_SETTINGS *k2settings)
 #endif /* HAVE_OCR_LIB */
     }
 
+#endif
 
 #ifdef HAVE_OCR_LIB
 /*

--- a/k2pdfoptlib/k2pdfopt.h
+++ b/k2pdfoptlib/k2pdfopt.h
@@ -653,6 +653,8 @@ typedef struct
     HYPHENINFO hyphen;
     } WRAPBMP;
 
+#if 0
+
 typedef struct
     {
     int rowcount;
@@ -666,6 +668,8 @@ typedef struct
     int na;
     } QUEUED_PAGE_INFO;
 
+#endif
+
 /*
 ** MASTERINFO contains performance parameters relevant to the device output.
 ** (E.g. the "master" bitmap which is a running scroll of content meant to
@@ -673,16 +677,20 @@ typedef struct
 */
 typedef struct
     {
+#if 0
     char srcfilename[MAXFILENAMELEN];
     char ocrfilename[MAXFILENAMELEN];
     int outline_srcpage_completed; /* Which source page was last checked in the outline */
     PDFFILE outfile;      /* PDF output file data structure */
     WPDFOUTLINE *outline; /* PDF outline / bookmarks structure--loaded by MuPDF only */
+#endif
     WILLUSBITMAP bmp; /* Master output bitmap collects pages that will go to */
                       /* the output device */
     OCRWORDS mi_ocrwords;/* Queue of OCR bitmaps that have positions corresponding to */
                          /* the master bitmap -- v2.53 */
+#if 0
     QUEUED_PAGE_INFO queued_page_info; /* Queued up output pages */
+#endif
     WILLUSBITMAP *preview_bitmap;
     K2PAGEBREAKMARKS k2pagebreakmarks; /* User-specified page breaks */
     int preview_captured;  /* = 1 if preview bitmap obtained */
@@ -704,9 +712,11 @@ typedef struct
     int bgcolor;
     int fit_to_page;
     int wordcount;
+#if 0
     /* v2.42 for bitmap output and improved autocrop */
     int output_page_count;  /* Count in output file */
     int filecount;
+#endif
     int autocrop_margins[4];
     /* end v2.42 */
     char debugfolder[256];

--- a/k2pdfoptlib/k2proc.c
+++ b/k2pdfoptlib/k2proc.c
@@ -2372,6 +2372,7 @@ textrows_echo(&region->textrows,"rows");
 #if (WILLUSDEBUGX & 1)
 printf("Marking source page...\n");
 #endif
+#ifdef K2PDFOPT_DEBUG
     mark_source_page(k2settings,masterinfo,region,1,0xf);
     if (k2settings->debug)
         {
@@ -2382,6 +2383,7 @@ printf("Marking source page...\n");
             k2printf("@bmpregion_vertically_break (allow break) (%d,%d) - (%d,%d) (scale=%g)\n",
                 region->c1,region->r1,region->c2,region->r2,added_region.force_scale);
         }
+#endif
 #if (WILLUSDEBUGX & 1)
 printf("Tagging blank rows and columns...\n");
 #endif
@@ -2705,8 +2707,10 @@ printf("ADDING %s ROWS %d - %d OUT OF %d ...\n",added_region->notes?"NOTES":"MAI
             c2=textrow[j].c2;
         }
     marking_flags=(added_region->firstrow==0?0:1)|(added_region->lastrow==n-1?0:2);
+#ifdef K2PDFOPT_DEBUG
     /* Green or Magenta (for notes) */
     mark_source_page(k2settings,masterinfo,region,added_region->notes?4:3,added_region->notes?0xf:marking_flags);
+#endif
     region->bbox.type=REGION_TYPE_MULTILINE;
     region->bbox.c1=region->c1;
     region->bbox.c2=region->c2;
@@ -3086,7 +3090,9 @@ printf("assigned lcheight\n");
         marking_flags=(i==mlp->i1?0:1)|(i==mlp->i2?0:2);
         if (i<mlp->i2 || textrow->r2-textrow->rowbase>1)
             marking_flags |= 0x10;
+#ifdef K2PDFOPT_DEBUG
         textrow_mark_source(textrow,region,masterinfo,k2settings,marking_flags);
+#endif
 #if (WILLUSDEBUGX & 1)
 k2printf("   Row %2d: (%4d,%4d) - (%4d,%4d) rowbase=%4d, ch=%d, lch=%d, h5050=%d, rh=%d, nch=%d\n",i-mlp->i1+1,textrow->c1,textrow->r1,textrow->c2,textrow->r2,textrow->rowbase,textrow->capheight,textrow->lcheight,textrow->h5050,textrow->rowheight,nch);
 #endif
@@ -3474,6 +3480,7 @@ printf("        Too small for font.  Adjusted to %g\n",row_line_spacing_pixels);
     return((int)(row_line_spacing_pixels+.5));
     }
 
+#ifdef K2PDFOPT_DEBUG
 
 static void textrow_mark_source(TEXTROW *textrow,BMPREGION *region,MASTERINFO *masterinfo,
                                 K2PDFOPT_SETTINGS *k2settings,int marking_flags)
@@ -3504,6 +3511,7 @@ static void textrow_mark_source(TEXTROW *textrow,BMPREGION *region,MASTERINFO *m
     bmpregion_free(newregion);
     }
 
+#endif
 
 /*
 ** pi = preserve indentation
@@ -3573,6 +3581,7 @@ k2printf("Before small gap removal, column breaks:\n");
 k2printf("After small gap removal, column breaks:\n");
 // textrows_echo(textwords,"words");
 #endif
+#ifdef K2PDFOPT_DEBUG
     if (k2settings->show_marked_source)
         for (i=0;i<n;i++)
             {
@@ -3584,6 +3593,7 @@ k2printf("After small gap removal, column breaks:\n");
             mark_source_page(k2settings,masterinfo,&xregion,2,marking_flags);
             bmpregion_free(&xregion);
             }
+#endif
 #if (WILLUSDEBUGX & 4)
 for (i=0;i<n;i++)
 k2printf("    textword[%d] = %d - %d\n",i,textword[i].c1,textword[i].c2);

--- a/k2pdfoptlib/k2settings.c
+++ b/k2pdfoptlib/k2settings.c
@@ -244,7 +244,11 @@ void k2pdfopt_settings_init(K2PDFOPT_SETTINGS *k2settings)
 int k2settings_output_is_bitmap(K2PDFOPT_SETTINGS *k2settings)
 
     {
+#if 0
     return(filename_is_bitmap(k2settings->dst_opname_format));
+#else
+    return 0;
+#endif
     }
 
 
@@ -336,6 +340,7 @@ printf("    retval=%d\n",retval);
     return(retval);
     }
     
+#if 0
 
 void k2pdfopt_conversion_init(K2PDFOPT_CONVERSION *k2conv)
 
@@ -353,6 +358,7 @@ void k2pdfopt_conversion_close(K2PDFOPT_CONVERSION *k2conv)
     k2pdfopt_files_free(&k2conv->k2files);
     }
 
+#endif
 
 void k2pdfopt_settings_copy(K2PDFOPT_SETTINGS *dst,K2PDFOPT_SETTINGS *src)
 

--- a/k2pdfoptlib/k2sys.c
+++ b/k2pdfoptlib/k2sys.c
@@ -25,6 +25,7 @@
 #include <android/log.h>
 #endif
 
+#if 0
 
 void k2sys_init(void)
 
@@ -144,6 +145,7 @@ void k2sys_header(char *s)
            k2pdfopt_compiler,k2pdfopt_os,k2pdfopt_chip);
     }
 
+#endif
 
 
 int k2printf(const char *fmt,...)

--- a/k2pdfoptlib/wrapbmp.c
+++ b/k2pdfoptlib/wrapbmp.c
@@ -796,6 +796,7 @@ static double wrectmap_hcompare(WRECTMAP *x1,WRECTMAP *x2)
     }
 
 
+#if (WILLUSDEBUGX2)
 void wrectmap_write_bmp(WRECTMAP *wrmap,int index,BMPREGION *region)
 
     {
@@ -854,3 +855,4 @@ aprintf(ANSI_MAGENTA "%s is %d x %d" ANSI_NORMAL "\n",filename,bmp->width,bmp->h
     bmp_write(bmp,filename,stdout,100);
     bmp_free(bmp);
     }
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,18 +10,63 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(Leptonica lept REQUIRED IMPORTED_TARGET)
 pkg_check_modules(Tesseract tesseract REQUIRED IMPORTED_TARGET)
 
-file(GLOB K2PDFOPTLIB_SRC ../k2pdfoptlib/*.c)
-file(GLOB WILLUSLIB_SRC ../willuslib/*.c)
-file(GLOB HDR *.h ../k2pdfoptlib/*.h ../willuslib/*.h)
-
 add_library(k2pdfopt SHARED
-    koptcrop.c koptimize.c koptocr.c koptreflow.c
+    koptcrop.c
+    koptimize.c
+    koptocr.c
+    koptreflow.c
     setting.c
     tesscapi.cpp
-    ${K2PDFOPTLIB_SRC} ${WILLUSLIB_SRC}
+    ../k2pdfoptlib/bmpregion.c
+    ../k2pdfoptlib/devprofile.c
+    ../k2pdfoptlib/k2bmp.c
+    ../k2pdfoptlib/k2file.c
+    ../k2pdfoptlib/k2master.c
+    ../k2pdfoptlib/k2mem.c
+    ../k2pdfoptlib/k2ocr.c
+    ../k2pdfoptlib/k2proc.c
+    ../k2pdfoptlib/k2settings.c
+    ../k2pdfoptlib/k2sys.c
+    ../k2pdfoptlib/k2version.c
+    ../k2pdfoptlib/pagelist.c
+    ../k2pdfoptlib/pageregions.c
+    ../k2pdfoptlib/textrows.c
+    ../k2pdfoptlib/textwords.c
+    ../k2pdfoptlib/wrapbmp.c
+    ../willuslib/ansi.c
+    ../willuslib/array.c
+    ../willuslib/bmp.c
+    ../willuslib/filelist.c
+    ../willuslib/gslpolyfit.c
+    ../willuslib/linux.c
+    ../willuslib/math.c
+    ../willuslib/mem.c
+    ../willuslib/ocr.c
+    ../willuslib/ocrgocr.c
+    ../willuslib/ocrtess.c
+    ../willuslib/ocrwords.c
+    ../willuslib/strbuf.c
+    ../willuslib/string.c
+    ../willuslib/token.c
+    ../willuslib/wfile.c
+    ../willuslib/wgui.c
+    ../willuslib/willusversion.c
+    ../willuslib/wleptonica.c
+    ../willuslib/wsys.c
 )
 set_target_properties(k2pdfopt PROPERTIES SOVERSION 2)
-target_compile_definitions(k2pdfopt PRIVATE BUILDING_LIBK2PDFOPT)
+target_compile_definitions(k2pdfopt PRIVATE BUILDING_LIBK2PDFOPT NO_FILELIST)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(k2pdfopt PRIVATE K2PDFOPT_DEBUG)
+    target_sources(k2pdfopt PRIVATE
+        ../k2pdfoptlib/k2mark.c
+        ../willuslib/dtcompress.c
+        ../willuslib/pdffonts.c
+        ../willuslib/pdfwrite.c
+        ../willuslib/wpdfoutline.c
+        ../willuslib/wpdfutil.c
+    )
+endif()
 if(DISABLED_LEGACY_ENGINE)
     target_compile_definitions(k2pdfopt PRIVATE DISABLED_LEGACY_ENGINE)
 endif()
@@ -32,4 +77,16 @@ if(ANDROID)
 endif()
 
 install(TARGETS k2pdfopt)
-install(FILES ${HDR} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/k2pdfopt)
+install(FILES
+    context.h
+    koptcrop.h
+    koptimize.h
+    koptocr.h
+    koptreflow.h
+    leptonica.h
+    setting.h
+    tesseract.h
+    ../k2pdfoptlib/k2pdfopt.h
+    ../willuslib/willus.h
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/k2pdfopt
+)

--- a/willuslib/ansi.c
+++ b/willuslib/ansi.c
@@ -49,8 +49,10 @@
 
 #define MAXSIZE 8000
 
+#if 0
 static int ansi_on=1;
 static char ansi_buffer[MAXSIZE];
+#endif
 
 static void ansi_code(FILE *f,int *args,int nargs,int code);
 static void ansi_parse(FILE *f,char *s);
@@ -110,11 +112,13 @@ int ansi_escape_code(char *s,int *len)
     }
         
 
+#if 0
 void ansi_set(int on)
 
     {
     ansi_on = on;
     }
+#endif
 
 
 int aprintf(const char *fmt,...)
@@ -329,16 +333,20 @@ int avprintf(FILE *f,const char *fmt,va_list args)
     else
 #endif
         {
+#if 0
         if (!ansi_on)
             {
             status=vsprintf(ansi_buffer,fmt,args);
             ansi_parse(f,ansi_buffer);
             }
         else
+#endif
             status=vfprintf(f,fmt,args);
         }
     return(status);
     }
+
+#if 0
 
 /*
 ** Returns 1 for success, 0 for fail.
@@ -488,6 +496,7 @@ static void ansi_code(FILE *f,int *args,int nargs,int code)
 #endif
     }
 
+#endif
 
 #ifdef WIN32
 static void ansi_win32_setcolor(FILE *f,int n)

--- a/willuslib/bmp.c
+++ b/willuslib/bmp.c
@@ -201,6 +201,8 @@ int bmp_get_pdf_pageno(void)
     return(willusbmp_pageno);
     }
 
+#ifdef K2PDFOPT_DEBUG
+
 /*
 ** Quality is ignored if not JPEG.
 */
@@ -326,6 +328,7 @@ int bmp_write_ico(WILLUSBITMAP *bmp,char *filename,FILE *out)
     return(0);
     }
     
+#endif
 
 
 /*
@@ -4549,7 +4552,7 @@ static double bmp_row_by_row_stdev(WILLUSBITMAP *bmp,int ccount,int whitethresh,
 
 
 double bmp_autostraighten(WILLUSBITMAP *src,WILLUSBITMAP *srcgrey,int white,double maxdegrees,
-                          double mindegrees,int debug,FILE *out)
+                          double mindegrees,int debug_arg,FILE *out)
 
     {
     int i,na,n,imax,maxpt;
@@ -4558,6 +4561,11 @@ double bmp_autostraighten(WILLUSBITMAP *src,WILLUSBITMAP *srcgrey,int white,doub
     FILE *f;
     static int rpc=0;
     static char *funcname="bmp_autostraighten";
+#ifdef K2PDFOPT_DEBUG
+    int debug = debug_arg;
+#else
+    const int debug = 0;
+#endif
 
     rpc++;
     f=NULL;

--- a/willuslib/filelist.c
+++ b/willuslib/filelist.c
@@ -1179,6 +1179,7 @@ index,dirname,include_only[0],recursive,dirstoo);
 /*
 printf("fdf(%s)\n",dirname);
 */
+#if 0
     is_archive = (recursive>1 && wfile_is_archive(dirname));
     if (is_archive)
         {
@@ -1187,6 +1188,7 @@ printf("fdf(%s)\n",dirname);
         wfile_unique_part(dir,fl->dir);
         return(filelist_recursive_archive_add(fl,index,dir,dirname,include_only,exclude,recursive,dirstoo));
         }
+#endif
     if (recursive || include_only[0][0]=='\0' || include_only[1][0]!='\0')
         wfile_fullname(wildspec,dirname,"*");
     else
@@ -1203,13 +1205,15 @@ printf("    Reg files...\n");
             continue
         /* WARNING: wfile_is_symlink() can be a slow call on a network drive! */;
         /* fstatus=wfile_status(wf.fullname); */ /* 1-24-18--remove this call to go faster */
-        is_archive=wfile_is_archive(wf.fullname);
         symlink=(wf.attr&WFILE_SYMLINK);
         if ((wf.attr&WFILE_DIR) && !symlink && (dirstoo!=1 || recursive))
             continue;
+#if 0
         /* If archive file and we want to look into archives, then skip it. */
+        is_archive=wfile_is_archive(wf.fullname);
         if (is_archive && recursive>1)
             continue;
+#endif
 /*
         if (fstatus==2 && (recursive || dirstoo==0 || dirstoo==2 || dirstoo==3))
             continue;
@@ -1239,7 +1243,11 @@ printf("        %s\n",wf.fullname);
         if (!strcmp(wf.basename,".") || !strcmp(wf.basename,".."))
             continue;
 
+#if 0
         archive = (recursive>1 && wfile_is_archive(wf.fullname));
+#else
+        archive = 0;
+#endif
         /* 1-24-18 -- don't call wfile_status */
         if (!(wf.attr&WFILE_DIR) && !archive)
 /*
@@ -1282,6 +1290,7 @@ printf("        %s\n",wf.fullname);
     }
 
 
+#if 0
 /*
 ** Ideally will unzip a zip file within a zip file when recursive == 3.  
 ** Right now it doesn't do this.
@@ -1389,6 +1398,7 @@ static int filelist_recursive_archive_add(FILELIST *dst,int index,
     filelist_free(fl);
     return(n);
     }
+#endif
 
 
 /*
@@ -1624,6 +1634,7 @@ int filelist_dir_name_match(char *pattern,char *dirname)
     return(pattern[len-1]=='*');
     }
 
+#if 0
 
 /*
 ** If the zip file or .7z file was made during standard time,
@@ -2140,6 +2151,7 @@ static int nexttoken(char *dst,char *src,int *index)
     return(-1);
     }
 
+#endif
 
 int filelist_add_entry(FILELIST *fl,FLENTRY *entry)
 
@@ -2342,6 +2354,7 @@ void filelist_new_entry_name(FILELIST *fl,int index,char *newname)
     }
 
 
+#if 0
 /*
 ** 2-24-22:  Works with sizes exceeding 2^31 bytes now
 */
@@ -2386,6 +2399,7 @@ int filelist_write_to_file(FILELIST *fl,char *filename)
         return(-5);
     return(0);
     }
+#endif
 
 
 /*
@@ -2427,6 +2441,7 @@ int filelist_write_to_file(FILELIST *fl,char *filename)
 */
 
 
+#if 0
 /*
 ** Should work with buffer sizes exceeding 2^31 bytes now
 */
@@ -2473,6 +2488,7 @@ int filelist_read_from_file(FILELIST *fl,char *filename)
         return(-5);
     return(0);
     }
+#endif
 
 /*
 void filelist_alloc(FILELIST *fl,int entries,int cps)

--- a/willuslib/linux.c
+++ b/willuslib/linux.c
@@ -41,6 +41,8 @@
 
 static int nextdir(char *dir,char *path,int *index);
 
+#ifndef NO_FILELIST
+
 int linux_which(char *exactname,char *exename)
 
     {
@@ -152,6 +154,7 @@ int linux_most_recent_in_path(char *exactname,char *wildcard)
     return(exactname[0]!='\0');
     }
 
+#endif
 
 static int nextdir(char *dir,char *path,int *index)
 

--- a/willuslib/ocrtess.c
+++ b/willuslib/ocrtess.c
@@ -156,7 +156,9 @@ char *ocrtess_langnames[] =
     "yo","yor","Yoruba",
     ""
     };
+#if 0
 static char *defurl = "raw.githubusercontent.com/tesseract-ocr/tessdata_%s/master";
+#endif
 
 static int ocrtess_lstm_file(char *filename);
 static int ocrtess_tess_file(char *filename);
@@ -317,6 +319,7 @@ void ocrtess_baselang(char *dst,char *src,int maxlen)
     }
         
 
+#if 0
 void ocrtess_url(char *url0,int maxlen,int fast)
 
     {
@@ -340,6 +343,7 @@ void ocrtess_url(char *url0,int maxlen,int fast)
                   url);
     xstrncpy(url0,httpurl,maxlen);
     }
+#endif
         
 
 /*

--- a/willuslib/ocrwords.c
+++ b/willuslib/ocrwords.c
@@ -588,6 +588,7 @@ static int ocrword_compare_position(OCRWORD *w1,OCRWORD *w2)
     return(w1->c - w2->c);
     }
 
+#if 0
 
 void ocrwords_to_easyplot(OCRWORDS *words,char *filename,int append,int *yoffset)
 
@@ -697,3 +698,4 @@ void ocrwords_echo(OCRWORDS *ocrwords,FILE *out,int count,int writebmp)
         }
     }
 
+#endif

--- a/willuslib/wfile.c
+++ b/willuslib/wfile.c
@@ -142,6 +142,7 @@ static double ularge_to_double(ULARGE_INTEGER *x);
 
 
 
+#if 0
 int wfile_is_archive(char *filename)
 
     {
@@ -153,6 +154,7 @@ int wfile_is_archive(char *filename)
             return(1);
     return(0);
     }
+#endif
 
 
 double wfile_file_age_secs(char *filename)

--- a/willuslib/wsys.c
+++ b/willuslib/wsys.c
@@ -376,6 +376,7 @@ void wsys_append_nul_redirect(char *s)
     }
 
 
+#ifndef NO_FILELIST
 int wsys_which(char *exactname,char *exename)
 
     {
@@ -391,7 +392,6 @@ int wsys_which(char *exactname,char *exename)
     }
 
 
-#ifndef NO_FILELIST
 int wsys_most_recent_in_path(char *exename,char *wildcard)
 
     {


### PR DESCRIPTION
Only compile what we need: this reduce the library code size (bss+data+text) by ~3.5 MB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/50)
<!-- Reviewable:end -->
