### PR TITLE
improve OCR API

### DIFF
--- a/lib/koptocr.c
+++ b/lib/koptocr.c
@@ -52,7 +52,7 @@ void k2pdfopt_tocr_init(char *datadir, char *lang) {
 	}
 }
 
-void k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
+int k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
 		int x, int y, int w, int h, int dpi,
 		char *word, int max_length,
 		char *datadir, char *lang, int ocr_type,
@@ -60,7 +60,7 @@ void k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
 	WILLUSBITMAP srcgrey;
 	k2pdfopt_tocr_init(datadir, lang);
 	if (tess_api == NULL)
-		return;
+		return 1;
 	bmp_init(&srcgrey);
 	if (src->bpp != 8) {
 		bmp_convert_to_greyscale_ex(&srcgrey, src);
@@ -77,6 +77,7 @@ void k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
 		word[0] = '\0';
 	ocrwords_free(&ocrwords);
 	bmp_free(&srcgrey);
+	return 0;
 }
 
 const char* k2pdfopt_tocr_get_language() {

--- a/lib/koptocr.h
+++ b/lib/koptocr.h
@@ -34,7 +34,7 @@ void k2pdfopt_tocr_end();
 const char* k2pdfopt_tocr_get_language();
 
 K2PDFOPT_EXPORT
-void k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
+int k2pdfopt_tocr_single_word(WILLUSBITMAP *src,
 		int x, int y, int w, int h, int dpi,
 		char *word, int max_length,
 		char *datadir, char *lang, int ocr_type,


### PR DESCRIPTION
Add error return to `k2pdfopt_tocr_single_word`, so the caller can differentiate between an initialization error (missing or bad tesseract data) and OCR failed (no results).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/56)
<!-- Reviewable:end -->
