### PR TITLE
koptocr: fix `k2pdfopt_tocr_end` prototype

### DIFF
--- a/lib/koptocr.c
+++ b/lib/koptocr.c
@@ -41,7 +41,7 @@ void* tess_api = NULL;
 
 void k2pdfopt_tocr_init(char *datadir, char *lang) {
 	if (tess_api != NULL && strncmp(lang, k2pdfopt_tocr_get_language(tess_api), 32)) {
-		k2pdfopt_tocr_end(tess_api);
+		k2pdfopt_tocr_end();
 	}
 	if (tess_api == NULL) {
 		int status;
@@ -84,7 +84,7 @@ const char* k2pdfopt_tocr_get_language() {
 	return tess_capi_get_init_language(tess_api);
 }
 
-void k2pdfopt_tocr_end() {
+void k2pdfopt_tocr_end(void) {
 	if (tess_api != NULL) {
 		ocrtess_end(tess_api);
 		tess_api = NULL;

--- a/lib/koptocr.h
+++ b/lib/koptocr.h
@@ -29,7 +29,7 @@
 void k2pdfopt_tocr_init(char *datadir, char *lang);
 
 K2PDFOPT_EXPORT
-void k2pdfopt_tocr_end();
+void k2pdfopt_tocr_end(void);
 
 const char* k2pdfopt_tocr_get_language();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/59)
<!-- Reviewable:end -->
