### PR TITLE
koptocr: fix build with GCC 15

### DIFF
--- a/lib/koptocr.c
+++ b/lib/koptocr.c
@@ -41,7 +41,7 @@ static int k2pdfopt_get_word_boxes_from_tesseract(PIX *pixs, int is_cjk,
 static void* tess_api = NULL;
 
 void k2pdfopt_tocr_init(char *datadir, char *lang) {
-	if (tess_api != NULL && strncmp(lang, k2pdfopt_tocr_get_language(tess_api), 32)) {
+	if (tess_api != NULL && strncmp(lang, k2pdfopt_tocr_get_language(), 32)) {
 		k2pdfopt_tocr_end();
 	}
 	if (tess_api == NULL) {


### PR DESCRIPTION
```
[…]/lib/koptocr.c:44:47: error: too many arguments to function ‘k2pdfopt_tocr_get_language’; expected 0, have 1
   44 |         if (tess_api != NULL && strncmp(lang, k2pdfopt_tocr_get_language(tess_api), 32)) {
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/61)
<!-- Reviewable:end -->
