### PR TITLE
White threshold

### DIFF
--- a/lib/context.h
+++ b/lib/context.h
@@ -50,6 +50,8 @@ typedef struct KOPTContext {
     int read_max_width;
     int read_max_height;
     int writing_direction;
+	int black_hex;
+	int white_hex;
 
     double zoom;
     double margin;

--- a/lib/context.h
+++ b/lib/context.h
@@ -50,8 +50,6 @@ typedef struct KOPTContext {
     int read_max_width;
     int read_max_height;
     int writing_direction;
-	int black_hex;
-	int white_hex;
 
     double zoom;
     double margin;

--- a/lib/context.h
+++ b/lib/context.h
@@ -35,6 +35,7 @@ typedef struct KOPTContext {
     int trim;
     int wrap;
     int white;
+    int paint_white;
     int indent;
     int rotate;
     int columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -59,7 +59,7 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
 	k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
-	k2settings->contrast_max = kctx->white < 255 && kctx->white > 0 ? (510. / kctx->white) : k2settings->contrast_max;
+	k2settings->contrast_max = kctx->white < 255 && kctx->white > 0 ? (5 * 255 / kctx->white) : k2settings->contrast_max;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -58,6 +58,7 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
+	k2settings->src_paintwhite = k2settings->src_whitethresh < 255 ? 1 : 0;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;
@@ -65,8 +66,6 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->user_src_dpi = kctx->dev_dpi*kctx->quality;
     k2settings->defect_size_pts = kctx->defect_size;
     k2settings->dst_gamma = kctx->contrast;
-    sprintf(k2settings->dst_fgcolor,"%x",kctx->black_hex);
-    sprintf(k2settings->dst_bgcolor,"%x",kctx->white_hex);
 
     if (kctx->writing_direction == 0)
         k2settings->src_left_to_right = 1;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -58,7 +58,7 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
-	k2settings->src_paintwhite = k2settings->src_whitethresh < 255 ? 1 : 0;
+	k2settings->src_paintwhite = 1;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -58,7 +58,8 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
-	k2settings->src_paintwhite = 1;
+	k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
+	k2settings->contrast_max = kctx->white < 255 && kctx->white > 0 ? (510. / kctx->white) : k2settings->contrast_max;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -58,7 +58,7 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
-	k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
+    k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -65,6 +65,8 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->user_src_dpi = kctx->dev_dpi*kctx->quality;
     k2settings->defect_size_pts = kctx->defect_size;
     k2settings->dst_gamma = kctx->contrast;
+    sprintf(k2settings->dst_fgcolor,"%x",kctx->black_hex);
+    sprintf(k2settings->dst_bgcolor,"%x",kctx->white_hex);
 
     if (kctx->writing_direction == 0)
         k2settings->src_left_to_right = 1;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -59,7 +59,6 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
 	k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
-	k2settings->contrast_max = kctx->white < 255 && kctx->white > 0 ? (5 * 255 / kctx->white) : k2settings->contrast_max;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -58,7 +58,7 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
     k2settings->src_whitethresh = kctx->white;
-    k2settings->src_paintwhite = kctx->white < 255 ? 1 : 0;
+    k2settings->src_paintwhite = kctx->paint_white;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;


### PR DESCRIPTION
This PR is currently open as #63 

Applies ['white threshold' option](https://github.com/koreader/koreader/pull/13994) that native `k2pdfopt` has (see [my reasoning for custom implementation of this in a pull request for MuPDF](https://github.com/koreader/koreader-base/pull/2115)):

<img src="https://github.com/user-attachments/assets/57973405-e9bd-48f3-8dae-d923ea14c419" width="300" />

<img src="https://github.com/user-attachments/assets/02273398-88d4-4c9e-87f1-23988e1eaca6" width="300" />

<img src="https://github.com/user-attachments/assets/2ca64985-0e4d-4d2d-9e13-69c59a45faf6" width="600" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/62)
<!-- Reviewable:end -->
