### PR TITLE
Add white threshold in koptcontext

### DIFF
--- a/lib/context.h
+++ b/lib/context.h
@@ -34,7 +34,8 @@ typedef struct {
 typedef struct KOPTContext {
     int trim;
     int wrap;
-    int white;
+    int white_threshold;
+    int paint_white_threshold;
     int indent;
     int rotate;
     int columns;

--- a/lib/setting.c
+++ b/lib/setting.c
@@ -57,7 +57,8 @@ void k2pdfopt_settings_init_from_koptcontext(K2PDFOPT_SETTINGS *k2settings, KOPT
     k2settings->dst_height = k2settings->dst_userheight;
     k2settings->vertical_line_spacing = kctx->line_spacing;
     k2settings->text_wrap = kctx->wrap;
-    k2settings->src_whitethresh = kctx->white;
+    k2settings->src_whitethresh = kctx->white_threshold;
+    k2settings->src_paintwhite = kctx->paint_white_threshold;
     k2settings->src_autostraighten = kctx->straighten;
     k2settings->preserve_indentation = kctx->indent;
     k2settings->max_columns = kctx->columns;


### PR DESCRIPTION
Allows to enable/disable white threshold in k2pdfopt
Suggested order of merges: this PR -> bump libk2pdfopt in koreader-base -> [koreader-base](https://github.com/koreader/koreader-base/pull/2363) -> bump koreader-base in koreader -> [koreader](https://github.com/koreader/koreader/pull/15412)

Yes yes I know @Frenzie you asked me to use the same short names as the k2pdfopt, but I did exactly the opposite and made them more verbose because I strongly dislike `whitethresh` and `paintwhite`. I thought it's better to have just one place with weird names instead of having them all over the place, especially considering that one would still see them in the line when searching `white_threshold` and `paint_white_threshold` which I'm going to use everywhere else.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/libk2pdfopt/64)
<!-- Reviewable:end -->
